### PR TITLE
Add gRPC Reflection to Enable Server API Discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 *.json
 *_log/
+tmp/

--- a/cmd/raft/main.go
+++ b/cmd/raft/main.go
@@ -14,11 +14,9 @@ import (
 
 func main() {
 	var (
-		idStr  string
-		numStr string
+		idStr string
 	)
 	flag.StringVar(&idStr, "id", "", "The ID to use (int32)")
-	flag.StringVar(&numStr, "num", "", "The Num to use (int32)")
 
 	flag.Parse()
 
@@ -26,26 +24,14 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	tnum, err := strconv.ParseInt(numStr, 10, 32)
-	if err != nil {
-		panic(err)
-	}
 
 	id := int32(tid)
-	num := int32(tnum)
-	peers := map[int32]*raft.Peer{}
-	for i := int32(0); i < num; i++ {
-		if i == id {
-			continue
-		}
-		peers[i] = raft.NewPeer(i, fmt.Sprintf("localhost:%d", 50000+i))
-	}
-	s := storage.NewFileStorage(fmt.Sprintf("raft_peer_%d_storage.json", id))
+	s := storage.NewFileStorage(fmt.Sprintf("tmp/raft_peer_%d_storage.json", id))
 	if err := s.Open(); err != nil {
 		panic(err)
 	}
 	defer s.Close()
-	l, err := log.NewLevelDBLogStorage(fmt.Sprintf("raft_peer_%d_log.db", id), 1000)
+	l, err := log.NewLevelDBLogStorage(fmt.Sprintf("tmp/raft_peer_%d_log.db", id), 1000)
 	if err != nil {
 		panic(err)
 	}
@@ -54,7 +40,7 @@ func main() {
 	svr := raft.NewServer(
 		id,
 		fmt.Sprintf("localhost:%d", 50000+id),
-		peers,
+		map[int32]*raft.Peer{},
 		s,
 		l,
 	)

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/nnaakkaaii/raft-gochannel/proto/peer/v1"
 )
@@ -156,6 +157,8 @@ func (s *Server) Run(ctx context.Context, commitCh chan<- Entry) error {
 
 	svr := grpc.NewServer()
 	peerv1.RegisterPeerServiceServer(svr, s)
+
+	reflection.Register(svr)
 
 	go svr.Serve(lis)
 	log.Printf("server listening at %v", lis.Addr())


### PR DESCRIPTION
# Add gRPC Reflection to Enable Server API Discovery

## Description:

This PR adds gRPC reflection to our server implementation. By enabling reflection, we make it possible for clients to dynamically discover the APIs provided by the server. This feature is particularly useful for tools like grpcurl, which can list and call available gRPC methods without requiring the server's proto files.

## Changes:

- Imported google.golang.org/grpc/reflection in the server setup file.
- Registered the reflection service with our gRPC server instance.
- This addition will facilitate easier debugging and interaction with the server during development and testing.