### PR TITLE
Fix Leader Election for Single-Peer Cluster in Raft Implementation

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -400,7 +400,7 @@ func (s *Server) sendRequestVotes(ctx context.Context, respCh chan<- bool) {
 
 	votes := make(chan bool)
 	go func(ch chan<- bool) {
-		count := 1
+		count := 0
 		for vote := range votes {
 			if vote {
 				count++
@@ -415,6 +415,7 @@ func (s *Server) sendRequestVotes(ctx context.Context, respCh chan<- bool) {
 		}
 		ch <- false
 	}(respCh)
+	votes <- true // own vote
 
 	demotes := make(chan int32)
 


### PR DESCRIPTION
# Fix Leader Election for Single-Peer Cluster in Raft Implementation

## Summary
This PR addresses an issue in the Raft consensus algorithm implementation where a single-peer cluster failed to elect a leader. The modification ensures that a server can become a leader when it is the only member in the cluster.

## Changes
Adjusted the initial vote count in sendRequestVotes to start from zero.
Explicitly added a vote for the server itself when starting the election process.

## Impact
With these changes, the Raft server will be correctly promoted to a leader in a single-peer setup, ensuring that the cluster remains functional and can make progress even in configurations with only one server.