### PR TITLE
Enhance Leader Confirmation in Single-Peer Raft Clusters

### DIFF
--- a/cmd/raft/main.go
+++ b/cmd/raft/main.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/nnaakkaaii/raft-gochannel/pkg/log"
-	"github.com/nnaakkaaii/raft-gochannel/pkg/raft"
-	"github.com/nnaakkaaii/raft-gochannel/pkg/storage"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/log"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/raft"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/storage"
 )
 
 func main() {

--- a/cmd/raft/main.go
+++ b/cmd/raft/main.go
@@ -52,9 +52,9 @@ func main() {
 	for {
 		select {
 		case commit := <-commitCh:
-			fmt.Printf("%v [%d] received commit %+v", time.Now(), id, commit)
+			fmt.Printf("%v [%d] received commit %+v\n", time.Now(), id, commit)
 		case <-ctx.Done():
-			fmt.Printf("%v [%d] %+v", time.Now(), id, ctx.Err())
+			fmt.Printf("%v [%d] %+v\n", time.Now(), id, ctx.Err())
 			return
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nnaakkaaii/raft-gochannel
+module github.com/nnaakkaaii/raft-go-sidecar
 
 go 1.21.5
 

--- a/pkg/log/leveldb.go
+++ b/pkg/log/leveldb.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 
-	"github.com/nnaakkaaii/raft-gochannel/pkg/raft"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/raft"
 )
 
 type LevelDBLogStorage struct {

--- a/pkg/log/leveldb_test.go
+++ b/pkg/log/leveldb_test.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/nnaakkaaii/raft-gochannel/pkg/raft"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/raft"
 )
 
 func setupLevelDBLogStorage(t *testing.T) (*LevelDBLogStorage, func()) {

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -362,7 +362,7 @@ func (s *Server) sendAppendEntries(ctx context.Context, respCh chan<- bool) {
 	}
 
 	go func() {
-		count := 1 // リーダー自身を含む
+		count := 0
 		for range matchIndexUpdated {
 			count++
 			if count*2 > len(s.peers.GetPeers())+1 {
@@ -372,6 +372,7 @@ func (s *Server) sendAppendEntries(ctx context.Context, respCh chan<- bool) {
 		}
 		respCh <- false
 	}()
+	matchIndexUpdated <- true // own voting
 
 	wg.Wait()
 	close(matchIndexUpdated)

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
-	"github.com/nnaakkaaii/raft-gochannel/proto/peer/v1"
+	"github.com/nnaakkaaii/raft-go-sidecar/proto/peer/v1"
 )
 
 type Role string

--- a/pkg/raft/utils.go
+++ b/pkg/raft/utils.go
@@ -1,6 +1,6 @@
 package raft
 
-import peerv1 "github.com/nnaakkaaii/raft-gochannel/proto/peer/v1"
+import "github.com/nnaakkaaii/raft-go-sidecar/proto/peer/v1"
 
 func synch[T any](
 	initialValue T,

--- a/pkg/storage/file.go
+++ b/pkg/storage/file.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/nnaakkaaii/raft-gochannel/pkg/raft"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/raft"
 )
 
 type FileStorage struct {

--- a/pkg/storage/file_test.go
+++ b/pkg/storage/file_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/nnaakkaaii/raft-gochannel/pkg/raft"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/raft"
 )
 
 func TestFileStorage(t *testing.T) {

--- a/script/clean-log/main.go
+++ b/script/clean-log/main.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/nnaakkaaii/raft-gochannel/pkg/log"
+
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/log"
 )
 
 func main() {

--- a/test/e2e/raft_test.go
+++ b/test/e2e/raft_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 
-	"github.com/nnaakkaaii/raft-gochannel/pkg/log"
-	"github.com/nnaakkaaii/raft-gochannel/pkg/raft"
-	"github.com/nnaakkaaii/raft-gochannel/pkg/storage"
-	"github.com/nnaakkaaii/raft-gochannel/proto/peer/v1"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/log"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/raft"
+	"github.com/nnaakkaaii/raft-go-sidecar/pkg/storage"
+	"github.com/nnaakkaaii/raft-go-sidecar/proto/peer/v1"
 )
 
 func tmp(test int, num int) (map[int]string, map[int]string, func()) {

--- a/tools/buf/go.mod
+++ b/tools/buf/go.mod
@@ -1,4 +1,4 @@
-module github.com/nnaakkaaii/raft-gochannel/tools/buf
+module github.com/nnaakkaaii/raft-go-sidecar/tools/buf
 
 go 1.21.5
 

--- a/tools/protoc-gen-go-grpc/go.mod
+++ b/tools/protoc-gen-go-grpc/go.mod
@@ -1,4 +1,4 @@
-module github.com/nnaakkaaii/raft-gochannel/tools/protoc-gen-go-grpc
+module github.com/nnaakkaaii/raft-go-sidecar/tools/protoc-gen-go-grpc
 
 go 1.21.5
 

--- a/tools/protoc-gen-go/go.mod
+++ b/tools/protoc-gen-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/nnaakkaaii/raft-gochannel/tools/protoc-gen-go
+module github.com/nnaakkaaii/raft-go-sidecar/tools/protoc-gen-go
 
 go 1.21.5
 


### PR DESCRIPTION
# Enhance Leader Confirmation in Single-Peer Raft Clusters

## Summary
This PR introduces an enhancement in the leader confirmation process within sendAppendEntries function for scenarios where the Raft cluster consists of a single peer. The change ensures reliable leader election and confirmation in single-peer configurations.

## Changes
- Adjusted the vote counting logic in sendAppendEntries to include the leader's own vote. This change is particularly crucial in single-peer clusters to enable the leader to confirm its own leadership.
- Added a line to explicitly count the leader's own vote in the leader confirmation process.

## Impact
The proposed modification guarantees that a single server in a Raft cluster can effectively elect itself as a leader and confirm its leadership, ensuring the cluster's operational integrity. This enhancement is particularly important for maintaining the functionality of Raft clusters in minimal configurations.